### PR TITLE
changed the number of trips to 5 before buzzer is activated

### DIFF
--- a/Ultrasonic/Core/Src/main.c
+++ b/Ultrasonic/Core/Src/main.c
@@ -150,16 +150,16 @@ int main(void)
 
 		alert+=distance;
 
-		  if(count%3==0){
+		  if(count%5==0){
 
-			if (alert/3.0 < 91){
+			if (alert/5.0 < 91){
 				sprintf(uartBuf, "ALERT ", distance);
 				HAL_UART_Transmit(&huart2, (uint8_t *)uartBuf, strlen(uartBuf), 100);
 				HAL_GPIO_WritePin(GPIOA, GPIO_PIN_0, GPIO_PIN_SET);
 
 			}
 
-			else if ((alert/3.0 > 91)){
+			else if ((alert/5.0 > 91)){
 
 				HAL_GPIO_WritePin(GPIOA, GPIO_PIN_0, GPIO_PIN_RESET);
 			}


### PR DESCRIPTION
To increase the accuracy of the system, the number of consecutive times the sensor must be "tripped" before the buzzer goes off must be 5. Without this, small inaccuracies or unimportant obstances reflected in the ultrasonic sensor's readings would cause the buzzer to go off erratically, distracting the driver unnecessarily.